### PR TITLE
Updates for handling breaking changes introduced by OpenZeppelin.

### DIFF
--- a/contracts/optional/GovernanceTokenWrapper.sol
+++ b/contracts/optional/GovernanceTokenWrapper.sol
@@ -30,4 +30,8 @@ contract MyToken is ERC20, ERC20Permit, ERC20Votes, ERC20Wrapper {
   function _burn(address account, uint256 amount) internal override(ERC20, ERC20Votes) {
     super._burn(account, amount);
   }
+
+  function decimals() public view override(ERC20, ERC20Wrapper) returns (uint8) {
+    return super.decimals();
+  }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,7 +6,6 @@ import "hardhat-gas-reporter"
 import "dotenv/config"
 import "solidity-coverage"
 import "hardhat-deploy"
-import "solidity-coverage"
 import { HardhatUserConfig } from "hardhat/config"
 
 const COINMARKETCAP_API_KEY = process.env.COINMARKETCAP_API_KEY || ""
@@ -30,7 +29,15 @@ const config: HardhatUserConfig = {
       chainId: 4,
     },
   },
-  solidity: "0.8.9",
+  solidity: {
+    version: "0.8.9",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
   etherscan: {
     apiKey: ETHERSCAN_API_KEY,
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@0.3.0-beta.12",
     "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.2",
-    "@openzeppelin/contracts": "^4.4.2",
+    "@openzeppelin/contracts": "^4.6.0",
     "@typechain/ethers-v5": "^9.0.0",
     "@typechain/hardhat": "^4.0.0",
     "@types/chai": "^4.3.0",

--- a/scripts/queue-and-execute.ts
+++ b/scripts/queue-and-execute.ts
@@ -36,7 +36,7 @@ export async function queueAndExecute() {
     descriptionHash
   )
   await executeTx.wait(1)
-  console.log(await box.retrieve().toString())
+  console.log(`Box value: ${await box.retrieve()}`)
 }
 
 queueAndExecute()

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,10 +590,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
-  integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
+"@openzeppelin/contracts@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
+  integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
OZ released v4.6.0 on 26 April 2022 and it has breaking changes [1].

This PR
- Updates GovernorContract, GovernanceTokenWrapper.

Note that as of today the Open Zeppelin Wizard's auto-generated
code does not reflect the breaking changes.

TESTS: ran `yarn hardhat test --deploy-fixture`. The flag wasn't necessary but added it
as some people may need it depending on their config.

[1] https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md#breaking-changes