### PR TITLE
fixed a bug in verification

### DIFF
--- a/deploy/03-deploy-governor-contract.ts
+++ b/deploy/03-deploy-governor-contract.ts
@@ -16,25 +16,26 @@ const deployGovernorContract: DeployFunction = async function (hre: HardhatRunti
   const { deployer } = await getNamedAccounts()
   const governanceToken = await get("GovernanceToken")
   const timeLock = await get("TimeLock")
-
-  log("----------------------------------------------------")
-  log("Deploying GovernorContract and waiting for confirmations...")
-  const governorContract = await deploy("GovernorContract", {
-    from: deployer,
-    args: [
+  const args = [
       governanceToken.address,
       timeLock.address,
       QUORUM_PERCENTAGE,
       VOTING_PERIOD,
       VOTING_DELAY,
-    ],
+  ]
+  
+  log("----------------------------------------------------")
+  log("Deploying GovernorContract and waiting for confirmations...")
+  const governorContract = await deploy("GovernorContract", {
+    from: deployer,
+    args, 
     log: true,
     // we need to wait if on a live network so we can verify properly
     waitConfirmations: networkConfig[network.name].blockConfirmations || 1,
   })
   log(`GovernorContract at ${governorContract.address}`)
   if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
-    await verify(governorContract.address, [])
+    await verify(governorContract.address, args)
   }
 }
 


### PR DESCRIPTION
The `verify` function was passed an empty array argument while the governor contract takes 5 arguments. I fixed it.