### PR TITLE
fix a typo in the Governor contract

### DIFF
--- a/contracts/governance_standard/GovernorContract.sol
+++ b/contracts/governance_standard/GovernorContract.sol
@@ -25,7 +25,7 @@ contract GovernorContract is
   )
     Governor("GovernorContract")
     GovernorSettings(
-      _votingDelay, /* 1 block */ // votind delay
+      _votingDelay, /* 1 block */ // voting delay
       _votingPeriod, // 45818, /* 1 week */ // voting period
       0 // proposal threshold
     )


### PR DESCRIPTION
In the constructor of GovernorContract, change the comment "votind delay" for "voting delay"