### PR TITLE
update TimeLock.sol and deploy script by adding admin constructor

### DIFF
--- a/contracts/governance_standard/TimeLock.sol
+++ b/contracts/governance_standard/TimeLock.sol
@@ -7,9 +7,17 @@ contract TimeLock is TimelockController {
   // minDelay is how long you have to wait before executing
   // proposers is the list of addresses that can propose
   // executors is the list of addresses that can execute
+   //`admin`: optional account to be granted admin role; disable with zero address  /**
+  /**
+   * IMPORTANT: The optional admin can aid with initial configuration of roles after deployment
+   * without being subject to delay, but this role should be subsequently renounced in favor of
+   * administration through timelocked proposals. Previous versions of this contract would assign
+   * this admin to the deployer automatically and should be renounced as well.
+   */
   constructor(
     uint256 minDelay,
     address[] memory proposers,
-    address[] memory executors
-  ) TimelockController(minDelay, proposers, executors) {}
+    address[] memory executors,
+    address admin
+  ) TimelockController(minDelay, proposers, executors, admin) {}
 }

--- a/deploy/02-deploy-time-lock.ts
+++ b/deploy/02-deploy-time-lock.ts
@@ -12,7 +12,13 @@ const deployTimeLock: DeployFunction = async function (hre: HardhatRuntimeEnviro
   log("Deploying TimeLock and waiting for confirmations...")
   const timeLock = await deploy("TimeLock", {
     from: deployer,
-    args: [MIN_DELAY, [], []],
+    /**
+     * Here we can set any address in admin role also zero address.
+     * previously In tutorial deployer has given admin role then
+     * renounced as well. in later section so we are doing the same by giving admin role to
+     * deployer and then renounced to keep the tutorial same.
+     */
+    args: [MIN_DELAY, [], [], deployer],
     log: true,
     // we need to wait if on a live network so we can verify properly
     waitConfirmations: networkConfig[network.name].blockConfirmations || 1,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@0.3.0-beta.12",
     "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.2",
-    "@openzeppelin/contracts": "^4.6.0",
+    "@openzeppelin/contracts": "^4.8.0",
     "@typechain/ethers-v5": "^9.0.0",
     "@typechain/hardhat": "^4.0.0",
     "@types/chai": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,10 +590,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
-  integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
+"@openzeppelin/contracts@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
+  integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
* `TimelockController`: During deployment, the TimelockController used to grant the `TIMELOCK_ADMIN_ROLE` to the deployer and to the timelock itself. The deployer was then expected to renounce this role once configuration of the timelock is over. Failing to renounce that role allows the deployer to change the timelock permissions (but not to bypass the delay for any time-locked actions). The role is no longer given to the deployer by default. So a new constructor parameter `admin` is added in current updated   `TimelockController`  .
* so I added this `admin` in `TimeLock.sol`  and in deploy script I made again `deployer` as admin since in further deploy script we have renounced admin role from `deployer` .
* Now every function is working fine